### PR TITLE
Fix issue with misplaced spinner

### DIFF
--- a/DGActivityIndicatorView/DGActivityIndicatorView.m
+++ b/DGActivityIndicatorView/DGActivityIndicatorView.m
@@ -239,12 +239,16 @@ static const CGFloat kDGActivityIndicatorDefaultSize = 40.0f;
     [super layoutSubviews];
     
     _animationLayer.frame = self.bounds;
-    
-    if (_animating) {
+
+    BOOL animating = _animating;
+
+    if (animating)
         [self stopAnimating];
-        [self setupAnimation];
+
+    [self setupAnimation];
+
+    if (animating)
         [self startAnimating];
-    }
 }
 
 @end


### PR DESCRIPTION
When the frame of the DGActivityIndicatorView changes after animations
have been set up but before they have been started, animations aren't
updated to the new frame resulting in a misplaced animation (sometimes
completely obscured).

This change ensures `setupAnimations` is called regardless if animations
are running or not.
